### PR TITLE
Recommend pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ ProgressBar Component for iOS, based on UIProgressView.
 
 ## Getting started
 
-```
-$ npm install @react-native-community/progress-view --save
+```sh
+npm install @react-native-community/progress-view --save
 ```
 
 or
 
-```
-$ yarn add @react-native-community/progress-view
+```sh
+yarn add @react-native-community/progress-view
 ```
 
 ### Linking
@@ -28,16 +28,16 @@ $ yarn add @react-native-community/progress-view
 
  The package is [automatically linked](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) when building the app. All you need to do is:
 
-```
-$ cd ios && pod install
+```sh
+npx pod-install
 ```
 
 - React Native <= 0.59
 
 Run the following commands
 
-```
-$ react-native link @react-native-community/progress-view
+```sh
+react-native link @react-native-community/progress-view
 ```
 
 ### Manual installation


### PR DESCRIPTION
# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
