### PR TITLE
Windows Fix: windows folder not loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "android",
     "ios",
     "js",
-     "windows",
+    "windows",
     "react-native-progress-view.podspec"
   ],
   "main": "js/index.js",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "android",
     "ios",
     "js",
+     "windows",
     "react-native-progress-view.podspec"
   ],
   "main": "js/index.js",


### PR DESCRIPTION
When running "yarn add @react-native-community/progress-view" the windows folder does not get added. I believe this is because its not in "files". Let me know if thats not the case. :)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
